### PR TITLE
Invalid JSON for GetBurnValidations

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ Get a list of all burned transactions.
   "State": "Success",
   "Type": "GetBurnValidations",
   "Nonce": 63804569790630801,
-  {
+  "Data": {
     "BurnValidations": [{
       "TXID": "0x123456789",
       "Cur": 1,


### PR DESCRIPTION
- The response JSON was missing the Data attribute.

- This commit add this missing value.